### PR TITLE
Improve tic-tac-toe UI

### DIFF
--- a/game-portal/src/app/pages/tic-tac-toe/tic-tac-toe.css
+++ b/game-portal/src/app/pages/tic-tac-toe/tic-tac-toe.css
@@ -1,6 +1,6 @@
 .board {
-  width: 300px;
-  height: 300px;
+  width: 450px;
+  height: 450px;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);
   gap: 5px;
@@ -8,7 +8,7 @@
 .cell {
   background: #f8f9fa;
   border: 1px solid #dee2e6;
-  font-size: 2rem;
+  font-size: 3rem;
   font-weight: bold;
   display: flex;
   align-items: center;
@@ -18,4 +18,20 @@
 }
 .board.disabled .cell {
   cursor: default;
+}
+
+/* Modal animation */
+.modal-content {
+  animation: popIn 0.4s ease-in-out;
+}
+
+@keyframes popIn {
+  from {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }

--- a/game-portal/src/app/pages/tic-tac-toe/tic-tac-toe.html
+++ b/game-portal/src/app/pages/tic-tac-toe/tic-tac-toe.html
@@ -6,8 +6,18 @@
     </button>
   </div>
   <div class="mt-3">
-    <p *ngIf="winner" class="h5">{{ winner === 'Draw' ? 'It\'s a draw!' : (winner + ' wins!') }}</p>
     <button class="btn btn-primary" (click)="reset()">Restart</button>
     <a routerLink="/" class="btn btn-link d-block mt-2">Back to Games</a>
+  </div>
+
+  <div class="modal fade show d-block" tabindex="-1" *ngIf="winner" style="background: rgba(0,0,0,0.5);">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-body text-center">
+          <h5 class="modal-title mb-3">{{ winner === 'Draw' ? 'It\'s a draw!' : (winner + ' wins!') }}</h5>
+          <button type="button" class="btn btn-primary" (click)="reset()">Play Again</button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- increase board size for tic-tac-toe
- show Bootstrap modal on win/draw with animation

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b265d4958832e9edcf8e004247adc