### PR TITLE
Add Minesweeper game

### DIFF
--- a/game-portal/src/app/app.routes.ts
+++ b/game-portal/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { GameList } from './pages/game-list/game-list';
 import { TicTacToe } from './pages/tic-tac-toe/tic-tac-toe';
 import { SnakeGame } from './pages/snake-game/snake-game';
 import { MemoryGame } from './pages/memory-game/memory-game';
+import { Minesweeper } from './pages/minesweeper/minesweeper';
 
 export const routes: Routes = [
   { path: '', component: GameList },
   { path: 'tic-tac-toe', component: TicTacToe },
   { path: 'snake', component: SnakeGame },
   { path: 'memory', component: MemoryGame },
+  { path: 'minesweeper', component: Minesweeper },
   { path: 'game/:id', component: GameDetail },
 ];

--- a/game-portal/src/app/app.ts
+++ b/game-portal/src/app/app.ts
@@ -12,8 +12,8 @@ export class App {
     this.title.setTitle('Free Game Portal - Play Browser Games');
 
     this.meta.addTags([
-      { name: 'description', content: 'Enjoy free classic browser games like Tic Tac Toe, Snake, and Memory Game. No login required.' },
-      { name: 'keywords', content: 'Free games, Angular games, browser games, tic tac toe, snake, memory, HTML5 games' },
+      { name: 'description', content: 'Enjoy free classic browser games like Tic Tac Toe, Snake, Memory Game and Minesweeper. No login required.' },
+      { name: 'keywords', content: 'Free games, Angular games, browser games, tic tac toe, snake, memory, minesweeper, HTML5 games' },
       { name: 'author', content: 'Hamza Shafique' },
       { name: 'robots', content: 'index, follow' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/game-portal/src/app/pages/game-list/game-list.ts
+++ b/game-portal/src/app/pages/game-list/game-list.ts
@@ -29,6 +29,12 @@ games = [
     name: 'Memory Game',
     description: 'Match the cards!',
    icon: 'https://cdn-icons-png.flaticon.com/512/3050/3050525.png'
+  },
+  {
+    route: '/minesweeper',
+    name: 'Minesweeper',
+    description: 'Clear the field without hitting mines.',
+    icon: 'https://img.icons8.com/ios-filled/200/000000/minesweeper.png'
   }
 ];
 

--- a/game-portal/src/app/pages/minesweeper/minesweeper.css
+++ b/game-portal/src/app/pages/minesweeper/minesweeper.css
@@ -1,0 +1,20 @@
+.board .row {
+  display: flex;
+}
+
+.cell {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #ccc;
+  background: #e9ecef;
+  padding: 0;
+  line-height: 1;
+}
+
+.cell:focus {
+  outline: none;
+}
+
+.cell span {
+  pointer-events: none;
+}

--- a/game-portal/src/app/pages/minesweeper/minesweeper.html
+++ b/game-portal/src/app/pages/minesweeper/minesweeper.html
@@ -1,0 +1,20 @@
+<div class="container py-4 text-center">
+  <h2 class="mb-3">Minesweeper</h2>
+  <div class="board mx-auto mb-3">
+    <div class="row" *ngFor="let row of board; let y = index">
+      <button class="cell" *ngFor="let cell of row; let x = index"
+              (click)="reveal(cell, x, y)"
+              (contextmenu)="toggleFlag(cell); $event.preventDefault()">
+        <span *ngIf="cell.revealed">
+          <span *ngIf="cell.mine">💣</span>
+          <span *ngIf="!cell.mine && cell.adjacent > 0">{{cell.adjacent}}</span>
+        </span>
+        <span *ngIf="!cell.revealed && cell.flagged">🚩</span>
+      </button>
+    </div>
+  </div>
+  <p *ngIf="gameOver && remaining === 0" class="text-success">You Win!</p>
+  <p *ngIf="gameOver && remaining > 0" class="text-danger">Game Over!</p>
+  <button class="btn btn-primary" (click)="reset()">Restart</button>
+  <a routerLink="/" class="btn btn-link d-block mt-2">Back to Games</a>
+</div>

--- a/game-portal/src/app/pages/minesweeper/minesweeper.ts
+++ b/game-portal/src/app/pages/minesweeper/minesweeper.ts
@@ -1,0 +1,114 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+interface Cell {
+  mine: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  adjacent: number;
+}
+
+@Component({
+  selector: 'app-minesweeper',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './minesweeper.html',
+  styleUrl: './minesweeper.css'
+})
+export class Minesweeper {
+  width = 8;
+  height = 8;
+  mines = 10;
+  board: Cell[][] = [];
+  gameOver = false;
+  remaining = 0;
+
+  constructor() {
+    this.reset();
+  }
+
+  reset(): void {
+    this.remaining = this.width * this.height - this.mines;
+    this.gameOver = false;
+    this.board = Array.from({ length: this.height }, () =>
+      Array.from({ length: this.width }, () => ({ mine: false, revealed: false, flagged: false, adjacent: 0 }))
+    );
+    // place mines
+    let placed = 0;
+    while (placed < this.mines) {
+      const x = Math.floor(Math.random() * this.width);
+      const y = Math.floor(Math.random() * this.height);
+      const cell = this.board[y][x];
+      if (!cell.mine) {
+        cell.mine = true;
+        placed++;
+      }
+    }
+    // calculate adjacent counts
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        if (!this.board[y][x].mine) {
+          this.board[y][x].adjacent = this.countAdjacent(x, y);
+        }
+      }
+    }
+  }
+
+  private countAdjacent(x: number, y: number): number {
+    let count = 0;
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && ny >= 0 && nx < this.width && ny < this.height && this.board[ny][nx].mine) {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  reveal(cell: Cell, x: number, y: number): void {
+    if (this.gameOver || cell.revealed || cell.flagged) return;
+    cell.revealed = true;
+    if (cell.mine) {
+      this.gameOver = true;
+      this.revealAll();
+      return;
+    }
+    this.remaining--;
+    if (cell.adjacent === 0) {
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && ny >= 0 && nx < this.width && ny < this.height) {
+            const neighbor = this.board[ny][nx];
+            if (!neighbor.revealed && !neighbor.flagged) {
+              this.reveal(neighbor, nx, ny);
+            }
+          }
+        }
+      }
+    }
+    if (this.remaining === 0) {
+      this.gameOver = true;
+    }
+  }
+
+  toggleFlag(cell: Cell): void {
+    if (this.gameOver || cell.revealed) return;
+    cell.flagged = !cell.flagged;
+  }
+
+  private revealAll(): void {
+    for (const row of this.board) {
+      for (const c of row) {
+        c.revealed = true;
+      }
+    }
+  }
+}

--- a/game-portal/src/index.html
+++ b/game-portal/src/index.html
@@ -5,21 +5,21 @@
 
   <!-- ✅ Title and SEO Meta -->
   <title>Free Game Portal - Play Browser Games</title>
-  <meta name="description" content="Play classic browser games built with Angular and Bootstrap. Enjoy Tic Tac Toe, Snake, and more — no login needed.">
-  <meta name="keywords" content="Free games, browser games, Angular, Tic Tac Toe, Snake game, Memory game">
+  <meta name="description" content="Play classic browser games built with Angular and Bootstrap. Enjoy Tic Tac Toe, Snake, Minesweeper and more — no login needed.">
+  <meta name="keywords" content="Free games, browser games, Angular, Tic Tac Toe, Snake game, Memory game, Minesweeper">
   <meta name="author" content="Hamza Shafique">
   <meta name="robots" content="index, follow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- ✅ Open Graph Tags for social sharing -->
   <meta property="og:title" content="Free Game Portal" />
-  <meta property="og:description" content="Play browser games like Tic Tac Toe and Snake for free!" />
+  <meta property="og:description" content="Play browser games like Tic Tac Toe, Snake and Minesweeper for free!" />
   <meta property="og:image" content="https://hamzash750.github.io/FreeGameRoom/preview.png" />
   <meta property="og:url" content="https://hamzash750.github.io/FreeGameRoom/" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Free Game Portal" />
-  <meta name="twitter:description" content="Enjoy browser games like Tic Tac Toe and Snake for free!" />
+  <meta name="twitter:description" content="Enjoy browser games like Tic Tac Toe, Snake and Minesweeper for free!" />
   <meta name="twitter:image" content="https://hamzash750.github.io/FreeGameRoom/preview.png" />
 
   <!-- ✅ Canonical URL should point to deployed domain -->


### PR DESCRIPTION
## Summary
- implement Minesweeper game page
- register Minesweeper route and add to game list
- update SEO meta tags for Minesweeper

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2e2e7dac832e85d1d23e46ba21f3